### PR TITLE
Name the binary file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ anyhow = "1.0.0"
 flate2 = "1.0.0"
 bio = "0.40.0"
 
-[lib]
+[[bin]]
 name = "genome_parser"
-path = "src/lib.rs"
+path = "src/bin/main.rs"


### PR DESCRIPTION
The crate is currently defined as a library crate and Cargo.toml does not define any binaries. I think this makes it so that the binary is compiled to target/release/main. This fix explicitly defines a binary with the name genome_parser, that goes to target/release/main.